### PR TITLE
Add unitree latest teleopt stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ List of books featuring CasADi
 Companies using CasADi (public disclosure)
  1. ionworks https://ion-works.com/
  2. Modelon
+ 3. [Unitree](https://www.unitree.com/) [teleopt stack](https://github.com/unitreerobotics/avp_teleoperate)
 
 Research projects using CasADi
  1. ROCSIS (KULeuven as partner)


### PR DESCRIPTION
Not sure if [open sourced demo stack](https://github.com/unitreerobotics/avp_teleoperate) can imply usage in internal code deployed in products.
Related [video demo](https://www.youtube.com/watch?v=pNjr2f_XHoo)